### PR TITLE
Possibilité de supprimer le dossier par défaut dans la gestion des flux

### DIFF
--- a/templates/marigolds/settings.html
+++ b/templates/marigolds/settings.html
@@ -75,13 +75,11 @@
 
                     {$feedsForFolder=$value->getFeeds()}
 
-                    <li>{if="$value->getId()==1"}<a id="defaultFolder"></a>{/if}
+                    <li>
                         <h1 class="folder left" ><span>{$value->getName()}</span> ({function="count($feedsForFolder)"})
 
                         <button  onclick="renameFolder(this,{$value->getId()})">{function="_t('RENAME')"}</button>
-                        {if="$value->getId()!='1'"}
                         <button  onclick="if(confirm('{function="_t('CONFIRM_DELETE_FOLDER')"}\n\n{$value->getName()}'))window.location='action.php?action=removeFolder&amp;id={$value->getId()}'">{function="_t('DELETE')"}</button>
-                        {/if}
 
 <div class="clear"></div>
                         </h1>


### PR DESCRIPTION
Hello à tous,

La gestion des flux ne permet pas de supprimer le dossier créé par défaut et comprend un lien vide. Il me semble que ce code n'est pas/plus vraiment utile. N'hésitez pas (@ldleman :wink:) à me dire si quelque chose m'a échappé.

Bonne journée et j'espère que vous allez bien.