### PR TITLE
Filtre sur le dernier évènement sur "marquer comme lu"

### DIFF
--- a/MysqlEntity.class.php
+++ b/MysqlEntity.class.php
@@ -235,13 +235,8 @@ class MysqlEntity
             if($i){$query .=',';}else{$i=true;}
             $query .= '`'.$column.'`="'.$this->secure($value, $column).'" ';
         }
-        $query .=' WHERE ';
+        $query .= $this->getWhereClause($columns2, $operation);
 
-        $i = false;
-        foreach ($columns2 as $column=>$value){
-            if($i){$query .='AND ';}else{$i=true;}
-            $query .= '`'.$column.'`'.$operation.'"'.$this->secure($value, $column).'" ';
-        }
         if($this->debug)echo '<hr>'.$this->CLASS_NAME.' ('.__METHOD__ .') : Requete --> '.$query.'<br>'.$this->dbconnector->connection->error;
         $this->customQuery($query);
     }

--- a/action.php
+++ b/action.php
@@ -152,6 +152,7 @@ switch ($action){
         $whereClause = array();
         $whereClause['unread'] = '1';
         if(isset($_['feed']))$whereClause['feed'] = $_['feed'];
+        if(isset($_['last-event-id']))$whereClause['id'] = '<= ' . $_['last-event-id'];
         $eventManager->change(array('unread'=>'0'),$whereClause);
         header('location: ./index.php');
     break;
@@ -162,7 +163,9 @@ switch ($action){
         $feeds = $feedManager->loadAllOnlyColumn('id',array('folder'=>$_['folder']));
 
         foreach($feeds as $feed){
-            $eventManager->change(array('unread'=>'0'),array('feed'=>$feed->getId()));
+            $whereClause['feed'] = $feed->getId();
+            if(isset($_['last-event-id']))$whereClause['id'] = '<= ' . $_['last-event-id'];
+            $eventManager->change(array('unread'=>'0'),$whereClause);
         }
 
         header('location: ./index.php');


### PR DESCRIPTION
L'envoi du dernier évènement affiché lors de l'action de "marquer comme lu" permet de ne pas en louper si une synchronisation a été effectuée entre temps.