### PR TITLE
FIX #381 - Ajoute | avant "par Idleman"

### DIFF
--- a/templates/marigolds/locale/en.json
+++ b/templates/marigolds/locale/en.json
@@ -39,7 +39,7 @@
  "EVENT_NUMBER_PER_PAGES":"Number of articles per page",
  "EXPORT":"Export",
  "EXPORT_FEED_OPML_FORMAT":"Export feeds as opml format",
- "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabulous news aggregator executed in $1 secondes by $2",
+ "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabulous news aggregator executed in $1 secondes | by $2",
  "FAVORITES":"Favorites",
  "FAVORITES_EVENTS":"Favorite articles ($1)",
  "FAVORIZE":"Favorize",

--- a/templates/marigolds/locale/eo.json
+++ b/templates/marigolds/locale/eo.json
@@ -39,7 +39,7 @@
  "EVENT_NUMBER_PER_PAGES":"Nombro da artikoloj paĝe",
  "EXPORT":"Elporto",
  "EXPORT_FEED_OPML_FORMAT":"Elporti la fluojn per formato OPML",
- "FABULOUS_AGGREGATOR_LAUNCHED_IN":"Miriga abonrilatilo lanĉita dum $1 sekundoj far $2",
+ "FABULOUS_AGGREGATOR_LAUNCHED_IN":"Miriga abonrilatilo lanĉita dum $1 sekundoj | far $2",
  "FAVORITES":"Legosignoj",
  "FAVORITES_EVENTS":"Artikoloj legosignitaj ($1)",
  "FAVORIZE":"Legosignigi",

--- a/templates/marigolds/locale/es.json
+++ b/templates/marigolds/locale/es.json
@@ -39,7 +39,7 @@
  "EVENT_NUMBER_PER_PAGES":"Número de articulos por página",
  "EXPORT":"Exportación ",
  "EXPORT_FEED_OPML_FORMAT":"Exportar los RSS con el formato OPML",
- "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabuloso agregador ejecutado en $1 segundos por $2",
+ "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabuloso agregador ejecutado en $1 segundos | por $2",
  "FAVORITES":"Favoritos",
  "FAVORITES_EVENTS":"Articulos favoritos ($1)",
  "FAVORIZE":"Marcar favorito",

--- a/templates/marigolds/locale/fr.json
+++ b/templates/marigolds/locale/fr.json
@@ -39,7 +39,7 @@
  "EVENT_NUMBER_PER_PAGES":"Nombre d’articles par page",
  "EXPORT":"Export",
  "EXPORT_FEED_OPML_FORMAT":"Exporter les flux au format OPML",
- "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabuleux agrégateur exécuté en $1 secondes par $2",
+ "FABULOUS_AGGREGATOR_LAUNCHED_IN":"fabuleux agrégateur exécuté en $1 secondes | par $2",
  "FAVORITES":"Favoris",
  "FAVORITES_EVENTS":"Articles favoris ($1)",
  "FAVORIZE":"Favoriser",


### PR DESCRIPTION
Sépare l'indication du temps de chargement de l'auteur initial de Leed.