### PR TITLE
Aucune description affichée si pas trouvée sur le dépôt

### DIFF
--- a/Plugin.class.php
+++ b/Plugin.class.php
@@ -204,7 +204,7 @@ class Plugin{
             if(!in_array(strtolower($repoName), $installedPluginsNames)) {
                 $infos[] = array(
                     'name' => $repoName,
-                    'description' => $repo->description,
+                    'description' => isset($repo->description) ? $repo->description : false,
                     'zipUrl' => 'https://github.com/'.$repo->full_name.'/archive/'.$repo->default_branch.'.zip'
                 );
             }

--- a/templates/marigolds/js/script.js
+++ b/templates/marigolds/js/script.js
@@ -204,18 +204,17 @@ function searchPlugin(keyword){
     })
         .done(function(data) {
             if(data.length > 0){
-            var tpl = '<h3>'+_t('PLUGINS_INSTALL_FROM_GITHUB_LEED_MARKET')+'</h3>';
+                var tpl = '<h3>'+_t('PLUGINS_INSTALL_FROM_GITHUB_LEED_MARKET')+'</h3>';
                 tpl += '<ul>';
                 for(i=0;i<data.length;i++){
                     var plugin = data[i];
-                    tpl +=
-                    '<li>'+
-                        '<ul>'+
-                            '<li><h4>Nom: </h4>'+plugin.name+'</li>'+
-                            '<li>'+plugin.description+'</li>'+
-                            '<li><button class="btn" onclick="installPlugin(\''+plugin.zipUrl+'\',$(this).parent());">Installer</button></li>'+
-                        '</ul>'+
-                    '</li>';
+                    tpl += '<li><ul>'+
+                        '<li><h4>Nom: </h4>'+plugin.name+'</li>';
+                    if(typeof(plugin.description) === 'string') {
+                        tpl += '<li>'+plugin.description+'</li>';
+                    }
+                    tpl += '<li><button class="btn" onclick="installPlugin(\''+plugin.zipUrl+'\',$(this).parent());">Installer</button></li>'+
+                        '</ul></li>';
                 }
                 tpl += '</ul>';
                 ghZone.html(tpl);

--- a/templates/marigolds/settings.html
+++ b/templates/marigolds/settings.html
@@ -292,7 +292,7 @@
 
                 <section class="pluginBloc">
                     <h2>{function="_t('PLUGINS')"} :</h2>
-                    <p>{function="_t('CAN_DOWNLOAD_PLUGINS')"} : <a href="https://github.com/ldleman/Leed-market/"> Leed Market</a>.</p>
+                    <p>{function="_t('CAN_DOWNLOAD_PLUGINS')"} : <a href="https://github.com/Leed-market/">Leed Market</a>.</p>
                     
                     {if="$myUser!=false"}
                     <ul class="pluginMenu">


### PR DESCRIPTION
Hello,
J'ai ajouté l'ensemble des plugins sur https://github.com/Leed-market et je me suis rendu compte que si aucune description n'était présent, le texte affiché dans Leed était "null". Cette PR corrige ça.