### PR TITLE
Remplacement ldleman/Leed-market par Leed-market

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Vous pouvez retrouver la FAQ du projet ici : http://projet.idleman.fr/leed/?page
 
 ### Plugins
 
-Le dépot [Leed market](https://github.com/ldleman/Leed-market) contient tous les plugins à jour et approuvés officiellement pour le logiciel Leed.
+Le dépot [Leed market](https://github.com/Leed-market) contient tous les plugins à jour et approuvés officiellement pour le logiciel Leed.
 
 ### Bibliothèques utilisées
 
@@ -125,7 +125,7 @@ You can find the project FAQ here : http://projet.idleman.fr/leed/?page=FAQ
 
 ### Plugins
 
-The [Leed-market](https://github.com/ldleman/Leed-market) repository contains all the plugins up to date and officially approved for Leed software.
+The [Leed-market](https://github.com/Leed-market) repository contains all the plugins up to date and officially approved for Leed software.
 
 ### Libraries used
 
@@ -194,7 +194,7 @@ Puede ver las preguntas más frecuentes sobre el proyecto aquí : http://projet.
 
 ### Complementos
 
-El repositorio [Leed market](https://github.com/ldleman/Leed-market) contiene todos los complementos oficialemente aprobados para Leed.
+El repositorio [Leed market](https://github.com/Leed-market) contiene todos los complementos oficialemente aprobados para Leed.
 
 ### Bibliotecas usadas
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -23,7 +23,7 @@
  "INSTALL_COMMENT_BDD":"(to be created before)",
  "INSTALL_COMMENT_HOST":"(Generally 'localhost')",
  "INSTALL_DISPLAY_CLEAR":"(will be displayed in clear)",
- "INSTALL_END":"You can customize your installation through many plugins available <a target='_blank' href='https://github.com/ldleman/Leed-market#leed-market'>Leed-market</a>.",
+ "INSTALL_END":"You can customize your installation through many plugins available <a target='_blank' href='https://github.com/Leed-market'>Leed-market</a>.",
  "INSTALL_ERROR_CONNEXION":"Unable to connect to database",
  "INSTALL_ERROR_CURL":"The required function 'curl_exec' is inaccessible on your server, please install the Curl module for PHP.",
  "INSTALL_ERROR_FILEGET":"The required function 'file_get_contents' is inaccessible on your server, check your version of PHP.",

--- a/locale/eo.json
+++ b/locale/eo.json
@@ -23,7 +23,7 @@
  "INSTALL_COMMENT_BDD":"(je krei antaŭe)",
  "INSTALL_COMMENT_HOST":"(Ĝenerale 'localhost')",
  "INSTALL_DISPLAY_CLEAR":"(estos afiŝita nekaŝe)",
- "INSTALL_END":"Vi povas adapti vian instalon danke al multaj kromaĵoj haveblaj ĉe <a target='_blank' href='https://github.com/ldleman/Leed-market#leed-market'>Leed-market</a>.",
+ "INSTALL_END":"Vi povas adapti vian instalon danke al multaj kromaĵoj haveblaj ĉe <a target='_blank' href='https://github.com/Leed-market'>Leed-market</a>.",
  "INSTALL_ERROR_CONNEXION":"Konekto neebla al datumbazo.",
  "INSTALL_ERROR_CURL":"La funkcio nepra 'curl_exec' ne akceseblas ĉe via servilo, kontrolu vian version de PHP.",
  "INSTALL_ERROR_FILEGET":"La funkcio nepra 'file_get_contents' ne akceseblas ĉe via servilo, kontrolu vian version de PHP.",

--- a/locale/es.json
+++ b/locale/es.json
@@ -23,7 +23,7 @@
  "INSTALL_COMMENT_BDD":"(crearlo antes)",
  "INSTALL_COMMENT_HOST":"(En general 'localhost')",
  "INSTALL_DISPLAY_CLEAR":"(no va a ser escrito cifrado en el campo)",
- "INSTALL_END":"Puede personalizar su instancia gracias a numerosos complementos que son disponibles sobre el <a target='_blank' href='https://github.com/ldleman/Leed-market#leed-market'>Leed-market</a>.",
+ "INSTALL_END":"Puede personalizar su instancia gracias a numerosos complementos que son disponibles sobre el <a target='_blank' href='https://github.com/Leed-market'>Leed-market</a>.",
  "INSTALL_ERROR_CONNEXION":"No se puede conectar a la base de datos.",
  "INSTALL_ERROR_CURL":"Se necesita la función 'curl_exec' pero no es disponible sobre el servidor. Por favor, instale el módulo Curl por PHP.",
  "INSTALL_ERROR_FILEGET":"Se necesita la función 'file_get_contents' pero no es disponible sobre el servidor. Verificar su versión de PHP.",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -23,7 +23,7 @@
  "INSTALL_COMMENT_BDD":"(à créer avant)",
  "INSTALL_COMMENT_HOST":"(Généralement 'localhost')",
  "INSTALL_DISPLAY_CLEAR":"(sera affiché en clair)",
- "INSTALL_END":"Vous pouvez personnaliser votre installation grâce à de nombreux plugins disponibles sur <a target='_blank' href='https://github.com/ldleman/Leed-market#leed-market'>Leed-market</a>.",
+ "INSTALL_END":"Vous pouvez personnaliser votre installation grâce à de nombreux plugins disponibles sur <a target='_blank' href='https://github.com/Leed-market'>Leed-market</a>.",
  "INSTALL_ERROR_CONNEXION":"Connexion impossible à la base de données.",
  "INSTALL_ERROR_CURL":"La fonction requise 'curl_exec' est inaccessible sur votre serveur, veuillez installer le module Curl de PHP.",
  "INSTALL_ERROR_FILEGET":"La fonction requise 'file_get_contents' est inaccessible sur votre serveur, vérifiez votre version de PHP.",

--- a/templates/marigolds-old/settings.html
+++ b/templates/marigolds-old/settings.html
@@ -291,7 +291,7 @@
 
                 <section class="pluginBloc">
                     <h2>{function="_t('PLUGINS')"} :</h2>
-                    <p>{function="_t('CAN_DOWNLOAD_PLUGINS')"} : <a href="https://github.com/ldleman/Leed-market/"> Leed Market</a>.</p>
+                    <p>{function="_t('CAN_DOWNLOAD_PLUGINS')"} : <a href="https://github.com/Leed-market/"> Leed Market</a>.</p>
                     
                     {if="$myUser!=false"}
                     <ul class="pluginMenu">


### PR DESCRIPTION
L'ancien market ne fonctionnait plus et je n'aimais pas la gestion d'un seul dépôt pour tous les plugins. Là, avec l'API de Github, c'est plus simple à gérer. Dépendre d'un service tiers n'est pas l'idéal mais c'était rapide et efficace. Ce commit remplace les dernières références à l'ancien Market à ma connaissance.