### PR TITLE
Fix échappement caractères sur la méthode truncate

### DIFF
--- a/Functions.class.php
+++ b/Functions.class.php
@@ -150,7 +150,7 @@ class Functions
         }
         $fin='…' ;
         $nb=$limit-1;
-        return mb_substr($str, 0, $nb, 'UTF-8').$fin;
+        return htmlentities(mb_substr($str, 0, $nb, 'UTF-8').$fin);
     }
 
 


### PR DESCRIPTION
Sans ça, le code n'est pas échappé au niveau de la fonction truncate.