### PR TITLE
Passe la version minimale de Php à 5.5 : password_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Leed est également compatible avec le format d'import/export [OPML](https://fr.
 ### Pré-requis
 
 - Serveur Apache conseillé (non testé sur les autres serveurs type Nginx…)
-- PHP 5.3 minimum
+- PHP 5.5 minimum
 - MySQL
 - Un peu de bon sens :-)
 
@@ -98,7 +98,7 @@ Leed is also compatible with [OPML](https://fr.wikipedia.org/wiki/OPML) import /
 ### Prerequisites
 
 - Recommended Apache server (not tested on other webservers such as Nginx…)
-- PHP 5.3 minimum
+- PHP 5.5 minimum
 - MySQL
 - A little common sense :-)
 
@@ -172,7 +172,7 @@ El script también está compatible con los archivos de exportación/importació
 ### Prerrequisito
 
 - Se recomienda Apache (non testé sur les autres serveurs type Nginx…)
-- PHP versión 5.3 mínima
+- PHP versión 5.5 mínima
 - MySQL
 - Un poco de sentido común ;-)
 

--- a/install.php
+++ b/install.php
@@ -124,7 +124,7 @@ if (!@function_exists('curl_exec')){
 }else{
     $test[$lib_success][] = _t('INSTALL_INFO_CURL');
 }
-if (@version_compare(PHP_VERSION, '5.1.0') <= 0){
+if (@version_compare(PHP_VERSION, '5.5.0') <= 0){
     $test[$lib_errors][] = _t('INSTALL_ERROR_PHPV', array(PHP_VERSION));
 }else{
     $test[$lib_success][] = _t('INSTALL_INFO_PHPV', array(PHP_VERSION));


### PR DESCRIPTION
Ne pas fusionner, je le ferai si vous êtes d'accord.

Je vais refondre la gestion des mots de passe en utilisant [password_hash](https://secure.php.net/manual/fr/faq.passwords.php#faq.passwords.fasthash) qui n'est disponible qu'à partir de la version 5.5.

Les hébergements que je connais gèrent tous plus que la v5.5. La v7 devient même le standard.

Utiliser _password_hash_ permettrait de se passer du sel stocké dans la table de configuration. En l'état, il faudrait même utiliser un sel par utilisateur... Mais là, cela devient inutile car le sel est intégré dans le mot de passe. De plus, on passe par une bibliothèque standard, il n'y aurait plus le sel à gérer.
